### PR TITLE
Consolidate copy task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,47 +26,28 @@ module.exports = function (grunt) {
 
     // Copies templates and assets from external modules and dirs
     copy: {
-
-      govuk_template: {
-        src: 'node_modules/govuk_template_mustache/views/layouts/govuk_template.html',
-        dest: 'govuk_modules/views/',
-        expand: true,
-        flatten: true,
-        filter: 'isFile'
+      assets: {
+        files: [{
+          expand: true,
+          cwd: 'app/assets/',
+          src: ['**/*', '!sass/**'],
+          dest: 'public/'
+        }]
       },
-
-      govuk_assets: {
-        files: [
-          {
-            expand: true,
-            src: '**',
-            cwd: 'node_modules/govuk_template_mustache/assets',
-            dest: 'govuk_modules/govuk_template/assets'
-          }
-        ]
+      govuk: {
+        files: [{
+          expand: true,
+          cwd: 'node_modules/govuk_frontend_toolkit/govuk_frontend_toolkit',
+          src: '**',
+          dest: 'govuk_modules/govuk_frontend_toolkit/'
+        },
+        {
+          expand: true,
+          cwd: 'node_modules/govuk_template_mustache/',
+          src: '**',
+          dest: 'govuk_modules/govuk_template/'
+        }]
       },
-
-      govuk_frontend_toolkit_scss: {
-        expand: true,
-        src: '**',
-        cwd: 'node_modules/govuk_frontend_toolkit/stylesheets/',
-        dest: 'govuk_modules/public/sass/'
-      },
-
-      govuk_frontend_toolkit_js: {
-        expand: true,
-        src: '**',
-        cwd: 'node_modules/govuk_frontend_toolkit/javascripts/',
-        dest: 'govuk_modules/public/javascripts/'
-      },
-
-      govuk_frontend_toolkit_img: {
-        expand: true,
-        src: '**',
-        cwd: 'node_modules/govuk_frontend_toolkit/images/',
-        dest: 'govuk_modules/public/images/'
-      },
-
     },
 
     // workaround for libsass
@@ -145,12 +126,8 @@ module.exports = function (grunt) {
   );
 
   grunt.registerTask('default', [
-    'copy:govuk_template',
-    'copy:govuk_assets',
+    'copy',
     'convert_template',
-    'copy:govuk_frontend_toolkit_scss',
-    'copy:govuk_frontend_toolkit_js',
-    'copy:govuk_frontend_toolkit_img',
     'replace',
     'sass',
     'concurrent:target'
@@ -160,12 +137,8 @@ module.exports = function (grunt) {
     'test_default',
     'Test that the default task runs the app',
     [
-      'copy:govuk_template',
-      'copy:govuk_assets',
+      'copy',
       'convert_template',
-      'copy:govuk_frontend_toolkit_scss',
-      'copy:govuk_frontend_toolkit_js',
-      'copy:govuk_frontend_toolkit_img',
       'replace',
       'sass'
     ]

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,7 +40,7 @@ module.exports = function (grunt) {
       govuk: {
         files: [{
           expand: true,
-          cwd: 'node_modules/govuk_frontend_toolkit/govuk_frontend_toolkit',
+          cwd: 'node_modules/govuk_frontend_toolkit/',
           src: '**',
           dest: 'govuk_modules/govuk_frontend_toolkit/'
         },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,7 +17,10 @@ module.exports = function (grunt) {
           'public/stylesheets/prism.css': 'public/sass/prism.scss',
         },
         options: {
-          includePaths: ['govuk_modules/public/sass'],
+          includePaths: [
+            'govuk_modules/govuk_template/assets/stylesheets',
+            'govuk_modules/govuk_frontend_toolkit/stylesheets'
+          ],
           outputStyle: 'expanded',
           imagePath: '../images'
         }

--- a/lib/template-conversion.js
+++ b/lib/template-conversion.js
@@ -1,7 +1,7 @@
 var Hogan = require('hogan.js'),
     fs = require('fs'),
     path = require('path'),
-    govukDir = path.normalize(__dirname + '/../govuk_modules/govuk_template'),
+    govukDir = path.normalize(__dirname + '/../govuk_modules/'),
     govukConfig = require(__dirname + '/template-config'),
     compiledTemplate,
     govukTemplate,
@@ -15,8 +15,8 @@ handleErr = function (err) {
 
 module.exports = {
   convert : function () {
-    govukTemplate = fs.readFileSync(govukDir + '/views/layouts/govuk_template.html', { encoding : 'utf-8' });
+    govukTemplate = fs.readFileSync(govukDir + '/govuk_template/views/layouts/govuk_template.html', { encoding : 'utf-8' });
     compiledTemplate = Hogan.compile(govukTemplate);
-    fs.writeFileSync(govukDir + '/views/layouts/govuk_template.html', compiledTemplate.render(govukConfig), { encoding : 'utf-8' });
+    fs.writeFileSync(govukDir + '/govuk_template/views/layouts/govuk_template.html', compiledTemplate.render(govukConfig), { encoding : 'utf-8' });
   }
 };

--- a/lib/template-conversion.js
+++ b/lib/template-conversion.js
@@ -1,7 +1,7 @@
 var Hogan = require('hogan.js'),
     fs = require('fs'),
     path = require('path'),
-    govukDir = path.normalize(__dirname + '/../govuk_modules'),
+    govukDir = path.normalize(__dirname + '/../govuk_modules/govuk_template'),
     govukConfig = require(__dirname + '/template-config'),
     compiledTemplate,
     govukTemplate,
@@ -15,8 +15,8 @@ handleErr = function (err) {
 
 module.exports = {
   convert : function () {
-    govukTemplate = fs.readFileSync(govukDir + '/views/govuk_template.html', { encoding : 'utf-8' });
+    govukTemplate = fs.readFileSync(govukDir + '/views/layouts/govuk_template.html', { encoding : 'utf-8' });
     compiledTemplate = Hogan.compile(govukTemplate);
-    fs.writeFileSync(govukDir + '/views/govuk_template.html', compiledTemplate.render(govukConfig), { encoding : 'utf-8' });
+    fs.writeFileSync(govukDir + '/views/layouts/govuk_template.html', compiledTemplate.render(govukConfig), { encoding : 'utf-8' });
   }
 };

--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ var express = require('express'),
 // Application settings
 app.engine('html', require(__dirname + '/lib/template-engine.js').__express);
 app.set('view engine', 'html');
-app.set('vendorViews', __dirname + '/govuk_modules/views');
+app.set('vendorViews', __dirname + '/govuk_modules/govuk_template/views/layouts');
 app.set('views', __dirname + '/app/views');
 
 // Middleware to serve static assets


### PR DESCRIPTION
Copy the govuk_template and govuk_frontend_toolkit to /govuk_modules

Update includePaths to add the new location of the template's stylesheets and the toolkit's partials.
